### PR TITLE
Aardvark to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode6.4
+osx_image: xcode7
 before_script:
     - bundle install
 script:

--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '1.3.2'
+  s.version  = '2.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'
@@ -8,5 +8,5 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/square/Aardvark.git', :tag => s.version }
   s.source_files = 'Aardvark/*.{h,m}', 'Categories/*.{h,m}', 'Other/*.{h,m}', 'Logging/*.{h,m}', 'Log Viewing/*.{h,m}', 'Bug Reporting/*.{h,m}'
   s.private_header_files = 'Categories/*.h', '**/*_Testing.h'
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '7.0'
 end

--- a/AardvarkSample/AardvarkSample.xcodeproj/project.pbxproj
+++ b/AardvarkSample/AardvarkSample.xcodeproj/project.pbxproj
@@ -47,6 +47,13 @@
 			remoteGlobalIDString = EAD1442019E073FB0065A1FF;
 			remoteInfo = Aardvark;
 		};
+		EA7756021C4828B3009C5C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EA4583EB19E654FF00E44882 /* Aardvark.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 4551A2C21BDACF9000F216D0;
+			remoteInfo = "Aardvark-iOS";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -166,6 +173,7 @@
 			children = (
 				EA4583F119E654FF00E44882 /* libAardvark.a */,
 				EA4583F319E654FF00E44882 /* AardvarkTests.xctest */,
+				EA7756031C4828B3009C5C92 /* Aardvark.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -265,6 +273,13 @@
 			fileType = wrapper.cfbundle;
 			path = AardvarkTests.xctest;
 			remoteRef = EA4583F219E654FF00E44882 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		EA7756031C4828B3009C5C92 /* Aardvark.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Aardvark.framework;
+			remoteRef = EA7756021C4828B3009C5C92 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -430,7 +445,7 @@
 				);
 				GCC_PREFIX_HEADER = "Other/AardvarkSample-Prefix.pch";
 				INFOPLIST_FILE = AardvarkSample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -448,7 +463,7 @@
 				);
 				GCC_PREFIX_HEADER = "Other/AardvarkSample-Prefix.pch";
 				INFOPLIST_FILE = AardvarkSample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Logging/ARKLogDistributor.m
+++ b/Logging/ARKLogDistributor.m
@@ -246,9 +246,11 @@
     UIImage *screenshot = nil;
     
     @try {
-        UIWindow *window = [[UIApplication sharedApplication] keyWindow];
-        UIGraphicsBeginImageContextWithOptions(window.bounds.size, YES, 0.0);
-        [window.layer renderInContext:UIGraphicsGetCurrentContext()];
+        CGRect const screenBounds = [UIScreen mainScreen].bounds;
+        UIGraphicsBeginImageContextWithOptions(screenBounds.size, NO, 0.0);
+        [[UIApplication sharedApplication].windows enumerateObjectsUsingBlock:^(__kindof UIWindow * _Nonnull window, NSUInteger index, BOOL * _Nonnull stop) {
+            [window drawViewHierarchyInRect:screenBounds afterScreenUpdates:NO];
+        }];
         screenshot = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
     }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are only three steps to get Aardvark logging and bug reporting up and runn
 #### Using [CocoaPods](https://cocoapods.org)
 
 ```
-platform :ios, '6.0'
+platform :ios, '7.0'
 pod 'Aardvark'
 ```
 
@@ -64,8 +64,8 @@ Want to log with Aardvark but don’t want to use Aardvark’s bug reporting too
 
 ## Requirements
 
-* Xcode 6.3 or later
-* iOS 6 or later
+* Xcode 7.0 or later
+* iOS 7 or later
 
 ## Contributing
 


### PR DESCRIPTION
- Aardvark version to 2.0
- Minimum deployment target bump to iOS 7.0
- Minimum Xcode version to 7.0
